### PR TITLE
Add new time types

### DIFF
--- a/test/number.js
+++ b/test/number.js
@@ -62,5 +62,101 @@ describe('#Util', () => {
 
       expect(number).to.be.a('number')
     })
+
+    it('Should return a timestamp number', () => {
+      const field = {
+        isArray: false,
+        noNull: true,
+        name: 'timestamp'
+      }
+
+      const number = randomNumberData(field)
+
+      expect(number).to.be.a('number')
+      expect(number).to.be.gt(0)
+    })
+
+    it('Should return a hammertime number', () => {
+      const field = {
+        isArray: false,
+        noNull: true,
+        name: 'hammertime'
+      }
+
+      const number = randomNumberData(field)
+
+      expect(number).to.be.a('number')
+      expect(number).to.be.gt(0)
+    })
+
+    it('Should return a hour number', () => {
+      const field = {
+        isArray: false,
+        noNull: true,
+        name: 'hour'
+      }
+
+      const number = randomNumberData(field)
+
+      expect(number).to.be.a('number')
+      expect(number).to.be.gte(0)
+      expect(number).to.be.lt(24)
+    })
+
+    it('Should return a minute number', () => {
+      const field = {
+        isArray: false,
+        noNull: true,
+        name: 'minute'
+      }
+
+      const number = randomNumberData(field)
+
+      expect(number).to.be.a('number')
+      expect(number).to.be.gte(0)
+      expect(number).to.be.lt(60)
+    })
+
+    it('Should return a second number', () => {
+      const field = {
+        isArray: false,
+        noNull: true,
+        name: 'second'
+      }
+
+      const number = randomNumberData(field)
+
+      expect(number).to.be.a('number')
+      expect(number).to.be.gte(0)
+      expect(number).to.be.lt(60)
+    })
+
+    it('Should return a millisecond number', () => {
+      const field = {
+        isArray: false,
+        noNull: true,
+        name: 'millisecond'
+      }
+
+      const number = randomNumberData(field)
+
+      expect(number).to.be.a('number')
+      expect(number).to.be.gte(0)
+      expect(number).to.be.lt(1000)
+    })
+
+    it('Should return a year number', () => {
+      const field = {
+        isArray: false,
+        noNull: true,
+        name: 'year'
+      }
+
+      const number = randomNumberData(field)
+
+      expect(number).to.be.a('number')
+      expect(number).to.be.gte(0)
+      expect(number).to.be.lt(2300)
+    })
   })
 })

--- a/test/string.js
+++ b/test/string.js
@@ -167,4 +167,30 @@ describe('#Util', () => {
       expect(string.length).to.be.gt(0)
     })
   })
+
+  it('Should create a timezone string', () => {
+    const field = {
+      isArray: false,
+      noNull: true,
+      name: 'timezone'
+    }
+
+    const string = randomStringData(field)
+
+    expect(string).to.be.a('string')
+    expect(string.length).to.be.gt(0)
+  })
+
+  it('Should create a weekday string', () => {
+    const field = {
+      isArray: false,
+      noNull: true,
+      name: 'weekday'
+    }
+
+    const string = randomStringData(field)
+
+    expect(string).to.be.a('string')
+    expect(string).to.be.oneOf(['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'])
+  })
 })

--- a/util/constants.js
+++ b/util/constants.js
@@ -34,11 +34,25 @@ const constants = {
   city: 'city',
   cities: 'cities',
   country: 'country',
-  countries: 'countries'
+  countries: 'countries',
+  timestamp: 'timestamp',
+  timestamps: 'timestamps',
+  hammertime: 'hammertime',
+  hammertimes: 'hammertimes',
   timezone: 'timezone',
   timezones: 'timezones',
   weekday: 'weekday',
   weekdays: 'weekdays',
+  hour: 'hour',
+  hours: 'hours',
+  minute: 'minute',
+  minutes: 'minutes',
+  second: 'second',
+  seconds: 'seconds',
+  millisecond: 'millisecond',
+  milliseconds: 'milliseconds',
+  year: 'year',
+  years: 'years'
 }
 
 module.exports = constants

--- a/util/constants.js
+++ b/util/constants.js
@@ -35,6 +35,10 @@ const constants = {
   cities: 'cities',
   country: 'country',
   countries: 'countries'
+  timezone: 'timezone',
+  timezones: 'timezones',
+  weekday: 'weekday',
+  weekdays: 'weekdays',
 }
 
 module.exports = constants

--- a/util/randomData/number.js
+++ b/util/randomData/number.js
@@ -42,6 +42,32 @@ function createDataType (field, float) {
     case constants.phone:
       return createPhone()
 
+    case constants.timestamp:
+    case constants.timestamps:
+      return chance.timestamp()
+
+    case constants.hammertime:
+    case constants.hammertimes:
+      return chance.hammertime()
+
+    case constants.hour:
+    case constants.hours:
+      return chance.hour()
+
+    case constants.minute:
+    case constants.minutes:
+    case constants.second:
+    case constants.seconds:
+      return chance.second()
+
+    case constants.millisecond:
+    case constants.milliseconds:
+      return chance.millisecond()
+
+    case constants.year:
+    case constants.years:
+      return parseInt(chance.year())
+
     default:
       return createRandomNumber()
   }

--- a/util/randomData/string.js
+++ b/util/randomData/string.js
@@ -84,6 +84,14 @@ function createDataType (fieldName) {
     case constants.id:
       return createId()
 
+    case constants.timezone:
+    case constants.timezones:
+      return chance.timezone().name
+
+    case constants.weekday:
+    case constants.weekdays:
+      return chance.weekday()
+
     default:
       return createString()
   }


### PR DESCRIPTION
closes issue  https://github.com/EasyGraphQL/easygraphql-mock/issues/7

Added chancejs Time types as string constants (weekday and  timezone) and number constants (timestamp, hammertime, hours, minutes, seconds, milliseconds and year)