### PR TITLE
Handle cycles where two or more types reference each other

### DIFF
--- a/lib/mockBuilder.js
+++ b/lib/mockBuilder.js
@@ -13,7 +13,7 @@ function mockBuilder (schemaCode, customMock) {
   const mockSchema = {}
   for (const type of Object.keys(schema)) {
     const mockField = memoizedField(type, customMock, schema)
-    if (JSON.stringify(mockField) !== JSON.stringify({})) {
+    if (Object.keys(mockField).length > 0) {
       mockSchema[type] = mockField
     }
   }

--- a/test/mockBuilder.js
+++ b/test/mockBuilder.js
@@ -99,6 +99,7 @@ describe('Create a mock of GraphQL Schema', () => {
 
   describe('Type User', () => {
     // type User {
+    //   me: Me!
     //   email: String!
     //   username: String!
     //   fullName: String!
@@ -123,6 +124,26 @@ describe('Create a mock of GraphQL Schema', () => {
       expect(mock.User.family.user.username).to.be.a('string')
       expect(mock.User.family.user.fullName).to.be.a('string')
       expect(mock.User.family.user.phone).to.be.a('string')
+    })
+
+    it('User mock should reference a Me mock with full set of mocked fields', () => {
+      expect(mock.User.me).to.exist
+      expect(mock.User.me.id).to.be.a('string')
+      expect(mock.User.me.id).to.be.eq('123')
+      expect(mock.User.me.username).to.be.a('array')
+      expect(mock.User.me.username[0]).to.be.a('string')
+      expect(mock.User.me.username[0]).to.be.eq('estrada9166')
+      expect(mock.User.me.fullName).to.be.a('string')
+      expect(mock.User.me.fullName).to.be.eq('Hello World!')
+      expect(mock.User.me.phone).to.be.a('array')
+      expect(mock.User.me.phone[0]).to.be.a('number')
+      expect(mock.User.me.apiKey).to.be.a('string')
+      expect(mock.User.me.users).to.exist
+      expect(mock.User.me.users[0].email).to.be.a('string')
+      expect(mock.User.me.users[0].family).to.exist
+      expect(mock.User.me.users[0].family.name).to.be.a('string')
+      expect(['Father', 'Mother', 'Brother']).to.include(mock.User.me.users[0].family.familyRelation)
+      expect(mock.User.me.verified).to.be.a('boolean')
     })
   })
 

--- a/test/schema/schema.gql
+++ b/test/schema/schema.gql
@@ -26,6 +26,7 @@ type Me {
 }
 
 type User {
+  me: Me!
   email: String!
   username: String!
   fullName: String!

--- a/util/index.js
+++ b/util/index.js
@@ -14,8 +14,12 @@ const memoize = (fn) => {
     if (type in cache) {
       return cache[type]
     } else {
-      const result = fn(type, customMock, schema, deepLevel)
+      // To handle cycles in schema types put a reference to the mocked field in
+      // the cache before attempting to compute its properties.
+      const result = {}
       cache[type] = result
+      const mock = fn(type, customMock, schema, deepLevel)
+      Object.assign(result, mock)
       return result
     }
   }


### PR DESCRIPTION
As an example I changed the test schema so that `User` has a field of type `Me`, so that each type references the other. Before this change the mocked fields for both types would be an empty object. After this change both mocked fields have all of the expected nested fields, and `User.me` has all of the same fields as the top-level `Me` mock.