### PR TITLE
Include all types in union lists

### DIFF
--- a/test/arrMockBuilderSchemas.js
+++ b/test/arrMockBuilderSchemas.js
@@ -55,6 +55,9 @@ describe('Parse arr of schemas into one obj', () => {
       expect(mock.Query.getSchools).to.exist
       expect(mock.Query.getLocations).to.exist
       expect(mock.Query.search).to.exist
+      expect(mock.Query.search.some(member => member.__typename === 'Student')).to.be.true
+      expect(mock.Query.search.some(member => member.__typename === 'School')).to.be.true
+      expect(mock.Query.search.some(member => member.__typename === 'Location')).to.be.true
     })
   })
 

--- a/util/index.js
+++ b/util/index.js
@@ -94,9 +94,9 @@ function createData (field, schemaName, customMock = {}, schema) {
               dataArr.push(selecteEnumVal(field, schema))
             // validate if is union
             } else if (schema[field.type].types.length > 0) {
-              const type = getUnionVal(field, schema)
-              dataArr.push(
-                memoizedField(type, customMock, schema)
+              const types = getUnionVals(field, schema)
+              types.forEach(type =>
+                dataArr.push(memoizedField(type, customMock, schema))
               )
             } else {
               dataArr.push(
@@ -139,6 +139,10 @@ function getUnionVal (field, schema) {
   const types = schema[field.type].types
   const selectedValue = randomNumber(0, types.length - 1)
   return types[selectedValue]
+}
+
+function getUnionVals (field, schema) {
+  return schema[field.type].types
 }
 
 module.exports = memoizedField


### PR DESCRIPTION
As discussed in #28 - this PR makes sure that a list of a union type returns elements of all the possible types.

I'm not best buddies with chai, so I apologise if there is a better way to declare the tests.